### PR TITLE
Fix undefined error caused by reduce return value

### DIFF
--- a/packages/remark-custom-element-to-hast/custom-element-parser.js
+++ b/packages/remark-custom-element-to-hast/custom-element-parser.js
@@ -45,7 +45,10 @@ function blockCustomElementFactory(componentWhitelist) {
         var nodes = acc.nodes;
         if (!stop) {
           if (!(n.type === 'element' || (n.type === 'text' && (n.value === ' ' || n.value === '\n')))) {
-            return [nodes, true];
+            return {
+              nodes: nodes, 
+              stop: true
+            };
           }
           nodes.push(n);
         }


### PR DESCRIPTION
Recent changes made the library throw undefined-related errors (see [this comment](https://github.com/fazouane-marouane/remark-jsx/issues/1#issuecomment-350264815) for stack trace details). This small patch fixes those errors by changing the return value of the reduce function.