### PR TITLE
feat(parser): add support for curly brackets syntax

### DIFF
--- a/packages/remark-custom-element-to-hast/example.js
+++ b/packages/remark-custom-element-to-hast/example.js
@@ -13,7 +13,9 @@ const md =
 
 _Hey!_
 
-<Note content="*Hello*" />
+<Note content={Hello} />
+<Note content={'Hello'} />
+<Note content={"Hello"} />
 
 A <Note content="This should be displayed">
   <Strong>Cool _test_</Strong> with some <InlineNote value="content"/>

--- a/packages/remark-custom-element-to-hast/smart-html-parser.js
+++ b/packages/remark-custom-element-to-hast/smart-html-parser.js
@@ -63,11 +63,11 @@ function pipeTokenizers(tokenizers, value) {
 }
 
 var attributeName = '[a-zA-Z_:][a-zA-Z0-9:._-]*';
-var unquoted = '([^"\'=<>`\\u0000-\\u0020]+)';
+var unquoted = '([^"\'=<>`\\u0000-\\u0020{}]+)';
 var singleQuoted = '\'([^\']*)\'';
 var doubleQuoted = '"([^"]*)"';
 var attributeValue = '(?:' + unquoted + '|' + singleQuoted + '|' + doubleQuoted + ')';
-var attribute = '(?:\\s+' + attributeName + '(?:\\s*=\\s*' + attributeValue + ')?)';
+var attribute = '(?:\\s+' + attributeName + '(?:\\s*={*\\s*' + attributeValue + '}*)?)';
 
 function smartHtmlParser(componentWhitelist) {
   var components = blockElements.concat(componentWhitelist).join('|');
@@ -75,7 +75,7 @@ function smartHtmlParser(componentWhitelist) {
   function parseOpeningTags(isAutoClosing, valueDesc) {
     return partialTokenizer(function (valueDesc) {
       var regexp = '<(' + components + ')(' + attribute + '*)\\s*' + (isAutoClosing ? '/>' : '>');
-      var propertiesRegex = '(' + attributeName + ')\\s*=\\s*' + attributeValue + '?';
+      var propertiesRegex = '(' + attributeName + ')\\s*={*\\s*' + attributeValue + '}*?';
       var matches = getAllMatches(regexp, valueDesc.value).map(function (match) {
         return {
           value: match[0],


### PR DESCRIPTION
Hi, I've been tinkering with this to make a workable plugin, and while testing out the parsing part (done by this lib) I noticed that whenever I used the curly brackets it would not interpret it as a component.

I'm not sure if this is something wanted or simply the lib have only been tested with string properties, but it's a simple edit in the regex and should take care of that.

It's probably a good idea to add tests for each notation to be sure we don't break anything in the future.